### PR TITLE
fix typo on vector code sample

### DIFF
--- a/docs/advanced-topics/managing-collections-with-vectors.md
+++ b/docs/advanced-topics/managing-collections-with-vectors.md
@@ -10,14 +10,14 @@ script {
 
     fun main() {
         // use generics to create an emtpy vector
-        let a = Vector::empty<&u8>();
+        let a = Vector::empty<u8>();
         let i = 0;
 
         // let's fill it with data
         while (i < 10) {
             Vector::push_back(&mut a, i);
             i = i + 1;
-        }
+        };
 
         // now print vector length
         let a_len = Vector::length(&a);


### PR DESCRIPTION
Before:

<img width="471" alt="image" src="https://user-images.githubusercontent.com/33358060/194969995-46cf116b-c3dc-474b-8bcc-6820e06dc0a2.png">

After:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/33358060/194970021-07e41c62-9f9f-462c-a923-d7db49c66286.png">
