### PR TITLE
remove typo from code block in resources-by-example

### DIFF
--- a/docs/resources/resource-by-example/access-resource-with-borrow.md
+++ b/docs/resources/resource-by-example/access-resource-with-borrow.md
@@ -67,8 +67,8 @@ module Collection {
 
     // ... skipped ...
 
-    public fun add_item(account: &signer) acquires T {
-        let collection = borrow_global_mut<T>(Signer::address_of(account));
+    public fun add_item(account: &signer) acquires Collection {
+        let collection = borrow_global_mut<Collection>(Signer::address_of(account));
 
         Vector::push_back(&mut collection.items, Item {});
     }

--- a/docs/resources/resource-by-example/storing-new-resource.md
+++ b/docs/resources/resource-by-example/storing-new-resource.md
@@ -38,7 +38,7 @@ module Collection {
     /// note that &signer type is passed here!
     public fun start_collection(account: &signer) {
         move_to<Collection>(account, Collection {
-            items: Vector::empty<Collection>()
+            items: Vector::empty<Item>()
         })
     }
 }


### PR DESCRIPTION
sample code block contain typo which does not compile.